### PR TITLE
Add charts to reports page and modernize UI

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,9 +1,172 @@
 body {
-    background-color: #f8f9fa;
+    background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 30%, #f1f5f9 100%);
+    font-family: 'Inter', sans-serif;
+    color: #1f2937;
+}
+
+main.container {
+    max-width: 1200px;
+}
+
+.navbar {
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.report-hero {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.9), rgba(147, 51, 234, 0.85));
+    border-radius: 1.75rem;
+    padding: 2.5rem;
+    box-shadow: 0 25px 50px -12px rgba(79, 70, 229, 0.35);
+}
+
+.report-filter .form-control {
+    min-width: 180px;
+    background-color: rgba(255, 255, 255, 0.12);
+    border: none;
+    color: #fff;
+}
+
+.report-filter .form-control::placeholder {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.report-filter .form-control::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+}
+
+.report-filter .form-control:focus {
+    background-color: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 0 0 0.15rem rgba(255, 255, 255, 0.35);
+    color: #fff;
+}
+
+.report-filter .btn {
+    border-radius: 999px;
+    padding-inline: 1.5rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
+}
+
+.card-modern {
+    border-radius: 1.25rem;
+    border: none;
+    background: #fff;
+}
+
+.kpi-card {
+    background: linear-gradient(145deg, #ffffff, #f8fafc);
+}
+
+.kpi-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: #94a3b8;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.kpi-value {
+    font-weight: 700;
+}
+
+.kpi-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 1rem;
+    font-size: 1.35rem;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+}
+
+.table-modern thead th {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    color: #94a3b8;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.table-modern tbody tr:not(:last-child) td {
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.table-modern tbody tr:hover {
+    background-color: #f8fafc;
+}
+
+.badge-soft-success {
+    color: #0f766e;
+    background-color: rgba(16, 185, 129, 0.12);
+}
+
+.badge-soft-danger {
+    color: #b91c1c;
+    background-color: rgba(248, 113, 113, 0.15);
+}
+
+.badge-soft-primary {
+    color: #1d4ed8;
+    background-color: rgba(59, 130, 246, 0.12);
+}
+
+.badge-soft-success,
+.badge-soft-danger,
+.badge-soft-primary {
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
+.category-dot {
+    display: inline-block;
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 999px;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+}
+
+.progress-thin {
+    height: 0.35rem;
+    background-color: #e2e8f0;
+}
+
+.progress-thin .progress-bar {
+    border-radius: 999px;
+}
+
+.report-chart-wrapper {
+    position: relative;
+    height: 280px;
+}
+
+@media (max-width: 767.98px) {
+    .report-hero {
+        padding: 2rem;
+    }
+
+    .report-chart-wrapper {
+        height: 230px;
+    }
+}
+
+.list-group-modern .list-group-item {
+    border: none;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0.85rem;
+    padding-bottom: 0.85rem;
+}
+
+.list-group-modern .list-group-item + .list-group-item {
+    border-top: 1px solid #e2e8f0;
 }
 
 .card-kpi {
     border-left: 5px solid #0d6efd;
+    border-radius: 1.25rem;
 }
 
 .table-actions {
@@ -11,5 +174,16 @@ body {
 }
 
 .progress-goal {
-    height: 20px;
+    height: 0.75rem;
+    background-color: #e2e8f0;
+    border-radius: 999px;
+}
+
+.progress-goal .progress-bar {
+    border-radius: 999px;
+}
+
+footer {
+    background: rgba(255, 255, 255, 0.65);
+    backdrop-filter: blur(10px);
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,4 +9,167 @@
             }
         });
     }
+
+    const chartConfig = window.reportChartsData;
+    if (chartConfig && typeof Chart !== 'undefined') {
+        const currency = String(chartConfig.currency || 'USD').toUpperCase();
+        const symbolMap = {
+            USD: '$',
+            EUR: '€',
+            GBP: '£',
+            CAD: 'C$',
+            AUD: 'A$',
+            JPY: '¥',
+            INR: '₹',
+            SUM: "so'm",
+        };
+        const suffixCurrencies = new Set(['INR', 'SUM']);
+        const zeroDecimalCurrencies = new Set(['JPY']);
+
+        const formatCurrency = (value) => {
+            const decimals = zeroDecimalCurrencies.has(currency) ? 0 : 2;
+            const absolute = Math.abs(value || 0);
+            const formatted = absolute.toLocaleString(undefined, {
+                minimumFractionDigits: decimals,
+                maximumFractionDigits: decimals,
+            });
+            const symbol = symbolMap[currency] || `${currency} `;
+            const result = suffixCurrencies.has(currency)
+                ? `${formatted} ${symbol}`
+                : `${symbol}${formatted}`;
+            return value < 0 ? `-${result}` : result;
+        };
+
+        const categoryConfig = chartConfig.category || {};
+        if (Array.isArray(categoryConfig.labels) && categoryConfig.labels.length) {
+            const ctx = document.getElementById('categoryChart');
+            if (ctx) {
+                const categoryChart = new Chart(ctx, {
+                    type: 'doughnut',
+                    data: {
+                        labels: categoryConfig.labels,
+                        datasets: [
+                            {
+                                data: categoryConfig.data || [],
+                                backgroundColor: categoryConfig.colors || [],
+                                hoverOffset: 4,
+                                borderWidth: 0,
+                            },
+                        ],
+                    },
+                    options: {
+                        cutout: '60%',
+                        plugins: {
+                            legend: {
+                                position: 'bottom',
+                                labels: {
+                                    usePointStyle: true,
+                                    boxWidth: 12,
+                                    boxHeight: 12,
+                                    padding: 16,
+                                },
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    label: (context) => {
+                                        const dataset = context.chart.data.datasets[context.datasetIndex];
+                                        const total = Array.isArray(dataset.data)
+                                            ? dataset.data.reduce((sum, value) => sum + (Number(value) || 0), 0)
+                                            : 0;
+                                        const rawValue = Number(context.parsed) || 0;
+                                        const share = total ? ((rawValue / total) * 100).toFixed(1) : '0.0';
+                                        return `${context.label}: ${formatCurrency(rawValue)} (${share}%)`;
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+                ctx.categoryChart = categoryChart;
+            }
+        }
+
+        const trendConfig = chartConfig.trends || {};
+        if (Array.isArray(trendConfig.labels) && trendConfig.labels.length) {
+            const trendCanvas = document.getElementById('trendChart');
+            if (trendCanvas) {
+                const trendChart = new Chart(trendCanvas, {
+                    type: 'line',
+                    data: {
+                        labels: trendConfig.labels,
+                        datasets: [
+                            {
+                                label: 'Income',
+                                data: trendConfig.income || [],
+                                borderColor: '#22c55e',
+                                backgroundColor: 'rgba(34, 197, 94, 0.2)',
+                                tension: 0.4,
+                                fill: false,
+                                pointRadius: 4,
+                                pointBackgroundColor: '#22c55e',
+                            },
+                            {
+                                label: 'Expenses',
+                                data: trendConfig.expense || [],
+                                borderColor: '#ef4444',
+                                backgroundColor: 'rgba(239, 68, 68, 0.18)',
+                                tension: 0.4,
+                                fill: false,
+                                pointRadius: 4,
+                                pointBackgroundColor: '#ef4444',
+                            },
+                            {
+                                type: 'bar',
+                                label: 'Net',
+                                data: trendConfig.net || [],
+                                backgroundColor: 'rgba(79, 70, 229, 0.35)',
+                                borderRadius: 6,
+                                borderSkipped: false,
+                                order: 0,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            y: {
+                                grid: {
+                                    color: 'rgba(148, 163, 184, 0.25)',
+                                },
+                                ticks: {
+                                    callback: (value) => formatCurrency(value),
+                                },
+                            },
+                            x: {
+                                grid: {
+                                    display: false,
+                                },
+                            },
+                        },
+                        plugins: {
+                            tooltip: {
+                                mode: 'index',
+                                intersect: false,
+                                callbacks: {
+                                    label: (context) => {
+                                        const rawValue = Number(context.parsed.y ?? context.parsed) || 0;
+                                        return `${context.dataset.label}: ${formatCurrency(rawValue)}`;
+                                    },
+                                },
+                            },
+                            legend: {
+                                labels: {
+                                    usePointStyle: true,
+                                    boxWidth: 12,
+                                    boxHeight: 12,
+                                },
+                            },
+                        },
+                    },
+                });
+                trendCanvas.trendChart = trendChart;
+            }
+        }
+    }
 })();

--- a/config/config.php
+++ b/config/config.php
@@ -55,6 +55,39 @@ function asset_url(string $path): string
     return url_for($path);
 }
 
+function currency_symbol(string $currency): string
+{
+    $map = [
+        'USD' => '$',
+        'EUR' => '€',
+        'GBP' => '£',
+        'CAD' => 'C$',
+        'AUD' => 'A$',
+        'JPY' => '¥',
+        'INR' => '₹',
+        'SUM' => "so'm",
+    ];
+
+    $currency = strtoupper($currency);
+
+    return $map[$currency] ?? $currency . ' ';
+}
+
+function format_currency(float $amount, string $currency, ?int $precision = null): string
+{
+    $currency = strtoupper($currency);
+    $precision = $precision ?? ($currency === 'JPY' ? 0 : 2);
+    $isNegative = $amount < 0;
+    $absolute = abs($amount);
+    $formatted = number_format($absolute, $precision);
+    $symbol = currency_symbol($currency);
+
+    $positionAfter = in_array($currency, ['INR', 'SUM'], true);
+    $value = $positionAfter ? $formatted . ' ' . $symbol : $symbol . $formatted;
+
+    return $isNegative ? '-' . $value : $value;
+}
+
 function redirect(string $path): void
 {
     if (!preg_match('/^https?:\/\//i', $path)) {

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -5,6 +5,7 @@
     </div>
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 <script src="<?= asset_url('assets/js/app.js'); ?>"></script>
 </body>
 </html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -9,7 +9,11 @@ $user = current_user();
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>BudgetMaster</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link href="<?= asset_url('assets/css/custom.css'); ?>" rel="stylesheet">
 </head>
 <body>

--- a/models/finance.php
+++ b/models/finance.php
@@ -9,6 +9,21 @@ function get_categories(int $user_id): array
     return $stmt->fetchAll();
 }
 
+function get_user_settings(int $user_id): array
+{
+    global $pdo;
+    $stmt = $pdo->prepare('SELECT * FROM settings WHERE user_id = ?');
+    $stmt->execute([$user_id]);
+    $settings = $stmt->fetch();
+
+    return $settings ?: [
+        'currency' => 'USD',
+        'locale' => 'en_US',
+        'notifications' => 1,
+        'dark_mode' => 0,
+    ];
+}
+
 function save_category(array $data): void
 {
     global $pdo;

--- a/public/reports.php
+++ b/public/reports.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../includes/auth.php';
 require_auth();
 require_once __DIR__ . '/../models/finance.php';
+
 $user = current_user();
 $start = $_GET['start'] ?? date('Y-m-01');
 $end = $_GET['end'] ?? date('Y-m-t');
@@ -9,115 +10,215 @@ $cashFlow = get_cash_flow($user['id'], $start, $end);
 $categorySummary = get_category_summary($user['id'], $start, $end);
 $trends = get_monthly_trends($user['id']);
 $transactions = get_transactions($user['id'], ['start_date' => $start, 'end_date' => $end]);
+$settings = get_user_settings($user['id']);
+$currency = $settings['currency'] ?? 'USD';
+$netCashFlow = $cashFlow['income'] - $cashFlow['expense'];
+$netClass = $netCashFlow >= 0 ? 'text-success' : 'text-danger';
+$categoryTotal = array_sum(array_map(fn($row) => (float) $row['total'], $categorySummary));
+$trendDisplay = array_map(function (array $trend) {
+    $date = DateTime::createFromFormat('Y-m', $trend['month']);
+    $trend['label'] = $date ? $date->format('M Y') : $trend['month'];
+    $trend['income'] = (float) $trend['income'];
+    $trend['expense'] = (float) $trend['expense'];
+    $trend['net'] = $trend['income'] - $trend['expense'];
+    return $trend;
+}, $trends);
+$chartPalette = ['#6366f1', '#14b8a6', '#f97316', '#22d3ee', '#a855f7', '#f43f5e', '#0ea5e9', '#84cc16', '#f59e0b', '#64748b'];
+$categoryColors = [];
+foreach ($categorySummary as $index => $row) {
+    $categoryColors[] = $chartPalette[$index % count($chartPalette)];
+}
+$chartConfig = [
+    'currency' => $currency,
+    'category' => [
+        'labels' => array_map(fn($row) => $row['name'], $categorySummary),
+        'data' => array_map(fn($row) => (float) $row['total'], $categorySummary),
+        'colors' => $categoryColors,
+    ],
+    'trends' => [
+        'labels' => array_map(fn($trend) => $trend['label'], $trendDisplay),
+        'income' => array_map(fn($trend) => $trend['income'], $trendDisplay),
+        'expense' => array_map(fn($trend) => $trend['expense'], $trendDisplay),
+        'net' => array_map(fn($trend) => $trend['net'], $trendDisplay),
+    ],
+];
+
 include __DIR__ . '/../includes/header.php';
 ?>
-<div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="h4">Reports & Insights</h1>
-    <form class="d-flex gap-2">
+<div class="report-hero d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-4 mb-4">
+    <div>
+        <span class="badge rounded-pill bg-white text-primary shadow-sm mb-2">Reports &amp; Insights</span>
+        <h1 class="display-6 fw-semibold text-white mb-2">Financial overview</h1>
+        <p class="lead text-white-50 mb-0">Stay on top of your income, expenses, and cash flow trends.</p>
+    </div>
+    <form class="d-flex flex-wrap gap-2 report-filter">
         <input type="date" name="start" value="<?= htmlspecialchars($start); ?>" class="form-control">
         <input type="date" name="end" value="<?= htmlspecialchars($end); ?>" class="form-control">
-        <button class="btn btn-outline-primary">Apply</button>
+        <button class="btn btn-light fw-semibold">Update range</button>
     </form>
 </div>
-<div class="row g-3 mb-3">
+<div class="row g-3 g-lg-4 mb-4">
     <div class="col-md-4">
-        <div class="card shadow-sm">
+        <div class="card card-modern kpi-card h-100 shadow-sm border-0">
             <div class="card-body">
-                <h6 class="text-muted text-uppercase">Income</h6>
-                <h2 class="fw-bold text-success">$<?= number_format($cashFlow['income'], 2); ?></h2>
+                <div class="d-flex align-items-start justify-content-between">
+                    <div>
+                        <span class="kpi-label text-uppercase">Income</span>
+                        <h2 class="kpi-value text-success mb-0"><?= format_currency((float) $cashFlow['income'], $currency); ?></h2>
+                    </div>
+                    <span class="kpi-icon bg-success-subtle text-success"><i class="bi bi-graph-up-arrow"></i></span>
+                </div>
             </div>
         </div>
     </div>
     <div class="col-md-4">
-        <div class="card shadow-sm">
+        <div class="card card-modern kpi-card h-100 shadow-sm border-0">
             <div class="card-body">
-                <h6 class="text-muted text-uppercase">Expenses</h6>
-                <h2 class="fw-bold text-danger">$<?= number_format($cashFlow['expense'], 2); ?></h2>
+                <div class="d-flex align-items-start justify-content-between">
+                    <div>
+                        <span class="kpi-label text-uppercase">Expenses</span>
+                        <h2 class="kpi-value text-danger mb-0"><?= format_currency((float) $cashFlow['expense'], $currency); ?></h2>
+                    </div>
+                    <span class="kpi-icon bg-danger-subtle text-danger"><i class="bi bi-cash-coin"></i></span>
+                </div>
             </div>
         </div>
     </div>
     <div class="col-md-4">
-        <div class="card shadow-sm">
+        <div class="card card-modern kpi-card h-100 shadow-sm border-0">
             <div class="card-body">
-                <h6 class="text-muted text-uppercase">Net Cash Flow</h6>
-                <h2 class="fw-bold <?= ($cashFlow['income'] - $cashFlow['expense']) >= 0 ? 'text-success' : 'text-danger'; ?>">
-                    $<?= number_format($cashFlow['income'] - $cashFlow['expense'], 2); ?>
-                </h2>
+                <div class="d-flex align-items-start justify-content-between">
+                    <div>
+                        <span class="kpi-label text-uppercase">Net Cash Flow</span>
+                        <h2 class="kpi-value <?= $netClass; ?> mb-0"><?= format_currency($netCashFlow, $currency); ?></h2>
+                    </div>
+                    <span class="kpi-icon bg-primary-subtle text-primary"><i class="bi bi-speedometer2"></i></span>
+                </div>
             </div>
         </div>
     </div>
 </div>
-<div class="card shadow-sm mb-3">
-    <div class="card-header">Category Breakdown</div>
+<div class="card card-modern mb-4 shadow-sm border-0">
+    <div class="card-header border-0 bg-transparent pb-0">
+        <div class="d-flex align-items-start align-items-md-center justify-content-between flex-column flex-md-row gap-2">
+            <div>
+                <h5 class="card-title mb-1">Spending breakdown</h5>
+                <small class="text-muted">Understand where your money goes by category.</small>
+            </div>
+        </div>
+    </div>
     <div class="card-body">
-        <div class="table-responsive">
-            <table class="table table-striped">
-                <thead>
-                    <tr>
-                        <th>Category</th>
-                        <th>Type</th>
-                        <th class="text-end">Amount</th>
-                        <th class="text-end">Share</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php $total = array_sum(array_column($categorySummary, 'total')); ?>
-                    <?php foreach ($categorySummary as $row): ?>
-                    <tr>
-                        <td><?= htmlspecialchars($row['name']); ?></td>
-                        <td><?= htmlspecialchars($row['type']); ?></td>
-                        <td class="text-end">$<?= number_format($row['total'], 2); ?></td>
-                        <td class="text-end"><?= $total ? round(($row['total'] / $total) * 100, 1) : 0; ?>%</td>
-                    </tr>
-                    <?php endforeach; ?>
-                    <?php if (!$categorySummary): ?>
-                    <tr><td colspan="4" class="text-center text-muted">No data for selected range.</td></tr>
-                    <?php endif; ?>
-                </tbody>
-            </table>
+        <div class="row g-4 align-items-center">
+            <div class="col-lg-5">
+                <?php if ($categorySummary): ?>
+                <div class="report-chart-wrapper">
+                    <canvas id="categoryChart"></canvas>
+                </div>
+                <?php else: ?>
+                <p class="text-muted small mb-0">Add transactions to see spending distribution.</p>
+                <?php endif; ?>
+            </div>
+            <div class="col-lg-7">
+                <div class="table-responsive">
+                    <table class="table table-modern align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th>Type</th>
+                                <th class="text-end">Amount</th>
+                                <th class="text-end">Share</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($categorySummary as $index => $row): ?>
+                            <?php $share = $categoryTotal ? round(($row['total'] / $categoryTotal) * 100, 1) : 0; ?>
+                            <tr>
+                                <td class="fw-semibold">
+                                    <span class="category-dot" style="background-color: <?= $categoryColors[$index] ?? '#0ea5e9'; ?>"></span>
+                                    <?= htmlspecialchars($row['name']); ?>
+                                </td>
+                                <td>
+                                    <span class="badge badge-soft-<?= $row['type'] === 'income' ? 'success' : 'danger'; ?> text-uppercase"><?= htmlspecialchars($row['type']); ?></span>
+                                </td>
+                                <td class="text-end fw-semibold"><?= format_currency((float) $row['total'], $currency); ?></td>
+                                <td class="text-end">
+                                    <div class="d-flex align-items-center gap-2 justify-content-end">
+                                        <span class="fw-semibold"><?= $share; ?>%</span>
+                                        <div class="progress progress-thin flex-grow-1">
+                                            <div class="progress-bar bg-primary" role="progressbar" style="width: <?= $share; ?>%"></div>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <?php endforeach; ?>
+                            <?php if (!$categorySummary): ?>
+                            <tr>
+                                <td colspan="4" class="text-center text-muted py-4">No data for selected range.</td>
+                            </tr>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 </div>
-<div class="card shadow-sm mb-3">
-    <div class="card-header">Monthly Trends</div>
+<div class="card card-modern mb-4 shadow-sm border-0">
+    <div class="card-header border-0 bg-transparent pb-0">
+        <div class="d-flex align-items-start align-items-md-center justify-content-between flex-column flex-md-row gap-2">
+            <div>
+                <h5 class="card-title mb-1">Monthly trends</h5>
+                <small class="text-muted">Track income and expenses over the past months.</small>
+            </div>
+        </div>
+    </div>
     <div class="card-body">
-        <div class="table-responsive">
-            <table class="table table-sm">
-                <thead>
-                    <tr>
-                        <th>Month</th>
-                        <th class="text-end">Income</th>
-                        <th class="text-end">Expense</th>
-                        <th class="text-end">Net</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($trends as $trend): ?>
-                    <tr>
-                        <td><?= htmlspecialchars($trend['month']); ?></td>
-                        <td class="text-end text-success">$<?= number_format($trend['income'], 2); ?></td>
-                        <td class="text-end text-danger">$<?= number_format($trend['expense'], 2); ?></td>
-                        <td class="text-end <?= ($trend['income'] - $trend['expense']) >= 0 ? 'text-success' : 'text-danger'; ?>">
-                            $<?= number_format($trend['income'] - $trend['expense'], 2); ?>
-                        </td>
-                    </tr>
+        <div class="row g-4">
+            <div class="col-lg-8">
+                <?php if ($trendDisplay): ?>
+                <div class="report-chart-wrapper">
+                    <canvas id="trendChart"></canvas>
+                </div>
+                <?php else: ?>
+                <p class="text-muted small mb-0">Add transactions to see trends.</p>
+                <?php endif; ?>
+            </div>
+            <div class="col-lg-4">
+                <?php if ($trendDisplay): ?>
+                <div class="list-group list-group-flush list-group-modern">
+                    <?php foreach ($trendDisplay as $trend): ?>
+                    <div class="list-group-item px-0">
+                        <div class="d-flex justify-content-between align-items-start gap-3">
+                            <div>
+                                <div class="fw-semibold"><?= htmlspecialchars($trend['label']); ?></div>
+                                <div class="small text-muted">Net <?= format_currency($trend['net'], $currency); ?></div>
+                            </div>
+                            <div class="text-end small">
+                                <div class="text-success"><?= format_currency($trend['income'], $currency); ?></div>
+                                <div class="text-danger"><?= format_currency($trend['expense'], $currency); ?></div>
+                            </div>
+                        </div>
+                    </div>
                     <?php endforeach; ?>
-                    <?php if (!$trends): ?>
-                    <tr><td colspan="4" class="text-center text-muted">Add transactions to see trends.</td></tr>
-                    <?php endif; ?>
-                </tbody>
-            </table>
+                </div>
+                <?php else: ?>
+                <p class="text-muted small mb-0">Add transactions to see monthly highlights.</p>
+                <?php endif; ?>
+            </div>
         </div>
     </div>
 </div>
-<div class="card shadow-sm">
-    <div class="card-header d-flex justify-content-between align-items-center">
-        <span>Detailed Transactions</span>
-        <a href="<?= url_for('public/transactions.php'); ?>" class="btn btn-sm btn-outline-primary">Manage</a>
+<div class="card card-modern shadow-sm border-0">
+    <div class="card-header border-0 bg-transparent d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <div>
+            <h5 class="card-title mb-0">Detailed transactions</h5>
+            <small class="text-muted">A quick view of activity for the selected period.</small>
+        </div>
+        <a href="<?= url_for('public/transactions.php'); ?>" class="btn btn-outline-primary btn-sm fw-semibold">Manage</a>
     </div>
     <div class="card-body p-0">
         <div class="table-responsive">
-            <table class="table table-striped mb-0">
+            <table class="table table-modern table-hover align-middle mb-0">
                 <thead>
                     <tr>
                         <th>Date</th>
@@ -135,16 +236,23 @@ include __DIR__ . '/../includes/header.php';
                         <td><?= htmlspecialchars($transaction['merchant'] ?? '-'); ?></td>
                         <td><?= htmlspecialchars($transaction['category_name']); ?></td>
                         <td><?= htmlspecialchars($transaction['account_name']); ?></td>
-                        <td><span class="badge bg-<?= $transaction['type'] === 'income' ? 'success' : 'danger'; ?> text-uppercase"><?= htmlspecialchars($transaction['type']); ?></span></td>
-                        <td class="text-end">$<?= number_format($transaction['amount'], 2); ?></td>
+                        <td>
+                            <span class="badge badge-soft-<?= $transaction['type'] === 'income' ? 'success' : 'danger'; ?> text-uppercase"><?= htmlspecialchars($transaction['type']); ?></span>
+                        </td>
+                        <td class="text-end fw-semibold"><?= format_currency((float) $transaction['amount'], $currency); ?></td>
                     </tr>
                     <?php endforeach; ?>
                     <?php if (!$transactions): ?>
-                    <tr><td colspan="6" class="text-center text-muted">No transactions for selected range.</td></tr>
+                    <tr>
+                        <td colspan="6" class="text-center text-muted py-4">No transactions for selected range.</td>
+                    </tr>
                     <?php endif; ?>
                 </tbody>
             </table>
         </div>
     </div>
 </div>
+<script>
+window.reportChartsData = <?= json_encode($chartConfig, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE); ?>;
+</script>
 <?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/public/settings.php
+++ b/public/settings.php
@@ -41,7 +41,7 @@ include __DIR__ . '/../includes/header.php';
                     <div class="mb-3">
                         <label class="form-label">Currency</label>
                         <select name="currency" class="form-select" required>
-                            <?php foreach (['USD','EUR','GBP','CAD','AUD','JPY','INR'] as $currency): ?>
+                            <?php foreach (['USD','EUR','GBP','CAD','AUD','JPY','INR','SUM'] as $currency): ?>
                             <option value="<?= $currency; ?>" <?= $settings['currency'] === $currency ? 'selected' : ''; ?>><?= $currency; ?></option>
                             <?php endforeach; ?>
                         </select>


### PR DESCRIPTION
## Summary
- add currency helpers and SUM currency support to respect user settings
- redesign the reports experience with updated styling, KPI cards, and embedded Chart.js visualizations
- extend shared assets with modern typography, icons, and chart-ready JavaScript

## Testing
- php -l config/config.php
- php -l models/finance.php
- php -l public/reports.php
- php -l public/settings.php

------
https://chatgpt.com/codex/tasks/task_e_68e021e95f1c832286b0e841bf34c30b